### PR TITLE
feat: updated server with latest settings for 0.1.0-beta

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,51 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.13.3
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@v1.12.0
+
+      - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/ojp-server/Chart.yaml
+++ b/charts/ojp-server/Chart.yaml
@@ -5,4 +5,4 @@ description: A OJP Server Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/Open-JDBC-Proxy/ojp/refs/heads/main/documents/images/ojp_logo.png
 type: application
 version: 0.1.0
-appVersion: "0.0.4-alpha"
+appVersion: "0.1.0-beta"

--- a/charts/ojp-server/Chart.yaml
+++ b/charts/ojp-server/Chart.yaml
@@ -4,9 +4,9 @@ home: https://github.com/ojp/ojp-helm
 description: A OJP Server Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/Open-JDBC-Proxy/ojp/refs/heads/main/documents/images/ojp_logo.png
 maintainers:
-  - name: rrobetti (Rogerio rrobetti)
+  - name: rrobetti
     url: https://github.com/rrobetti
-  - name: petruki (Roger Florinao)
+  - name: petruki
     url: https://github.com/petruki
 
 type: application

--- a/charts/ojp-server/Chart.yaml
+++ b/charts/ojp-server/Chart.yaml
@@ -4,5 +4,5 @@ home: https://github.com/ojp/ojp-helm
 description: A OJP Server Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/Open-JDBC-Proxy/ojp/refs/heads/main/documents/images/ojp_logo.png
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0-beta"

--- a/charts/ojp-server/Chart.yaml
+++ b/charts/ojp-server/Chart.yaml
@@ -3,6 +3,12 @@ name: ojp-server
 home: https://github.com/ojp/ojp-helm
 description: A OJP Server Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/Open-JDBC-Proxy/ojp/refs/heads/main/documents/images/ojp_logo.png
+maintainers:
+  - name: rrobetti (Rogerio rrobetti)
+    url: https://github.com/rrobetti
+  - name: petruki (Roger Florinao)
+    url: https://github.com/petruki
+
 type: application
 version: 0.1.1
 appVersion: "0.1.0-beta"

--- a/charts/ojp-server/README.md
+++ b/charts/ojp-server/README.md
@@ -27,10 +27,19 @@ helm uninstall ojp-server --namespace ojp
 | `server.port`            | OJP Server Port                               | `1059`                 |
 | `server.prometheusPort`  | OJP Server Prometheus Port                    | `9090`                 |
 | `server.threadPoolSize`  | OJP Server Thread Pool Size                   | `200`                  |
+| `server.maxRequestSize`  | OJP Server Max Request Size                   | `4194304`              |
+| `server.connectionIdleTimeout` | OJP Server Connection Idle Timeout | `30000`               |
 | `server.circuitBreakerTimeout` | OJP Server Circuit Breaker Timeout | `60000`               |
+| `server.circuitBreakerThreshold` | OJP Server Circuit Breaker Threshold | `3`               |
 | `server.allowedIps`       | OJP Server Allowed IPs                        | `0.0.0.0/0`           |
 | `server.prometheusAllowedIps` | OJP Server Prometheus Allowed IPs | `0.0.0.0/0`           |
 | `server.opentelemetry.enabled` | OJP Server OpenTelemetry Enabled   | `true`                |
+| `server.opentelemetry.endpoint` | OJP Server OpenTelemetry Endpoint | `` |
+| `server.slowQuerySegregation.enabled` | OJP Server Slow Query Segregation Enabled | `true` |
+| `server.slowQuerySegregation.slowSlotPercentage` | OJP Server Slow Query Segregation Slow Slot Percentage | `20` |
+| `server.slowQuerySegregation.idleTimeout` | OJP Server Slow Query Segregation Idle Timeout | `10000` |
+| `server.slowQuerySegregation.slowSlotTimeout` | OJP Server Slow Query Segregation Slow Slot Timeout | `120000` |
+| `server.slowQuerySegregation.fastSlotTimeout` | OJP Server Slow Query Segregation Fast Slot Timeout | `60000` |
 | `server.logLevel`        | OJP Server Log Level                       | `INFO`                |
 
 

--- a/charts/ojp-server/templates/configmap.yaml
+++ b/charts/ojp-server/templates/configmap.yaml
@@ -9,8 +9,17 @@ data:
   OJP_SERVER_PORT: {{ .Values.server.port | quote }}
   OJP_PROMETHEUS_PORT: {{ .Values.server.prometheusPort | quote }}
   OJP_SERVER_THREADPOOLSIZE: {{ .Values.server.threadPoolSize | quote }}
+  OJP_SERVER_MAXREQUESTSIZE: {{ .Values.server.maxRequestSize | quote }}
+  OJP_SERVER_CONNECTIONIDLETIMEOUT: {{ .Values.server.connectionIdleTimeout | quote }}
   OJP_SERVER_CIRCUITBREAKERTIMEOUT: {{ .Values.server.circuitBreakerTimeout | quote }}
+  OJP_SERVER_CIRCUITBREAKERTHRESHOLD: {{ .Values.server.circuitBreakerThreshold | quote }}
   OJP_SERVER_ALLOWEDIPS: {{ .Values.server.allowedIps | quote }}
   OJP_PROMETHEUS_ALLOWEDIPS: {{ .Values.server.prometheusAllowedIps | quote }}
   OJP_OPENTELEMETRY_ENABLED: {{ .Values.server.opentelemetry.enabled | quote }}
+  OJP_OPENTELEMETRY_ENDPOINT: {{ .Values.server.opentelemetry.endpoint | quote }}
+  OJP_SERVER_SLOWQUERYSEGREGATION_ENABLED: {{ .Values.server.slowQuerySegregation.enabled | quote }}
+  OJP_SERVER_SLOWQUERYSEGREGATION_SLOWSLOTPERCENTAGE: {{ .Values.server.slowQuerySegregation.slowSlotPercentage | quote }}
+  OJP_SERVER_SLOWQUERYSEGREGATION_IDLETIMEOUT: {{ .Values.server.slowQuerySegregation.idleTimeout | quote }}
+  OJP_SERVER_SLOWQUERYSEGREGATION_SLOWSLOTTIMEOUT: {{ .Values.server.slowQuerySegregation.slowSlotTimeout | quote }}
+  OJP_SERVER_SLOWQUERYSEGREGATION_FASTSLOTTIMEOUT: {{ .Values.server.slowQuerySegregation.fastSlotTimeout | quote }}
   OJP_SERVER_LOGLEVEL: {{ .Values.server.logLevel | quote }}

--- a/charts/ojp-server/templates/deployment.yaml
+++ b/charts/ojp-server/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             - name: prometheus
               containerPort: {{ .Values.server.prometheusPort }}
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: prometheus
+              scheme: HTTP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/ojp-server/templates/deployment.yaml
+++ b/charts/ojp-server/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
+            - configMapRef:
+                name: {{ include "ojp-server.fullname" . }}
             {{- with .Values.envFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/ojp-server/values.yaml
+++ b/charts/ojp-server/values.yaml
@@ -27,10 +27,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-envFrom:
-- configMapRef:
-    name: ojp-server
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/ojp-server/values.yaml
+++ b/charts/ojp-server/values.yaml
@@ -4,11 +4,21 @@ server:
   port: 1059
   prometheusPort: 9090
   threadPoolSize: 200
+  maxRequestSize: 4194304
+  connectionIdleTimeout: "30000"
   circuitBreakerTimeout: "60000"
+  circuitBreakerThreshold: 3
   allowedIps: "0.0.0.0/0"
   prometheusAllowedIps: "0.0.0.0/0"
   opentelemetry:
     enabled: true
+    endpoint: ""
+  slowQuerySegregation:
+    enabled: true
+    slowSlotPercentage: 20
+    idleTimeout: 10000
+    slowSlotTimeout: 120000
+    fastSlotTimeout: 60000
   logLevel: INFO
 
 image:


### PR DESCRIPTION
This pull request introduces significant improvements to the Helm chart for the OJP Server, mainly by expanding configuration options, updating the application version, and automating CI/CD processes for linting, testing, and releasing charts. The changes enhance the flexibility and manageability of the deployment while streamlining the development workflow.

**Helm Chart Configuration Enhancements:**

* Added new server configuration options in `values.yaml`, including `maxRequestSize`, `connectionIdleTimeout`, `circuitBreakerThreshold`, and a comprehensive `slowQuerySegregation` section, as well as support for OpenTelemetry endpoint configuration. These options are now documented in `README.md` and mapped in `configmap.yaml`. [[1]](diffhunk://#diff-a80f50bfc4f9713e176e2b7eb84085bf70e53c1202709d29313df8aad10ebce5R7-R21) [[2]](diffhunk://#diff-0451cc6c04a2547d1e43adeaa8e131206b8fdc60733d1f8b1758abaca782d5ffR30-R42) [[3]](diffhunk://#diff-6194a287f77e3ef9116d6e06de44f70a6f82a14f821354faed94b4b735d59890R12-R24)
* Updated the `appVersion` in `Chart.yaml` from `"0.0.4-alpha"` to `"0.1.0-beta"` to reflect the new feature additions and improvements.

**CI/CD Workflow Automation:**

* Added a new GitHub Actions workflow (`lint-test.yaml`) to automate linting and testing of Helm charts on pull requests, including DockerHub login, Helm setup, chart-testing, and KIND cluster creation for integration testing.
* Introduced a release workflow (`release.yml`) that automates chart publishing to GitHub Pages when changes are pushed to the `master` branch, using the `helm/chart-releaser-action`.